### PR TITLE
fix/flameshot

### DIFF
--- a/apps/user/desktop/env/core/apps/services/default.nix
+++ b/apps/user/desktop/env/core/apps/services/default.nix
@@ -1,12 +1,14 @@
 # Auto launch apps
 {
   lib,
-  pkgs,
   config,
   ...
 }:
+let
+  inherit (lib) hm optionalAttrs;
+in
 {
-  home.activation.mkSnapshotsDirAction = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.mkSnapshotsDirAction = hm.dag.entryAfter [ "writeBoundary" ] ''
     [ -d ${config.xdg.userDirs.pictures}/Screenshots ] || mkdir -p ${config.xdg.userDirs.pictures}/Screenshots
   '';
   services = {
@@ -20,6 +22,10 @@
           showStartupLaunchMessage = false;
           savePath = "${config.xdg.userDirs.pictures}/Screenshots";
           savePathFixed = true;
+        }
+        // optionalAttrs config.xsession.windowManager.qtile.enable {
+          useX11LegacyScreenshot = true;
+          captureActiveMonitor = true;
         };
       };
     };

--- a/apps/user/desktop/env/core/gnome/keyring/default.nix
+++ b/apps/user/desktop/env/core/gnome/keyring/default.nix
@@ -1,6 +1,7 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 {
   home.packages = [ pkgs.seahorse ];
+  xdg.portal.extraPortals = [ config.services.gnome-keyring.package ];
   services.gnome-keyring = {
     enable = true;
     components = [

--- a/machines/mother/home/default.nix
+++ b/machines/mother/home/default.nix
@@ -8,7 +8,6 @@
   };
   xdg.configFile = {
     "qtile/local_config.py".source = ./qtile/local_config.py;
-    "qtile/local_variables.py".source = ./qtile/local_variables.py;
   };
   sops.secrets = {
     "env" = {

--- a/machines/mother/home/qtile/local_variables.py
+++ b/machines/mother/home/qtile/local_variables.py
@@ -1,4 +1,0 @@
-from my_modules.variables import GlobalConf
-
-GlobalConf.pentab_output = "HDMI-3"
-GlobalConf.update_monitors()

--- a/machines/mother/system/gpu.nix
+++ b/machines/mother/system/gpu.nix
@@ -21,7 +21,6 @@
           BusID          "PCI:05:0:0"
           Option         "Monitor-DP-1" "DP-1"
           Option         "Monitor-HDMI-2" "HDMI-2"
-          Option         "Monitor-HDMI-3" "HDMI-3"
         EndSection
 
         Section "Device"
@@ -40,11 +39,6 @@
         Section "Monitor"
           Identifier     "HDMI-2"
           Option         "RightOf" "DP-1"
-        EndSection
-
-        Section "Monitor"
-          Identifier     "HDMI-3"
-          Option         "RightOf" "HDMI-2"
         EndSection
       '';
       # screenSection = ''

--- a/patches/default.nix
+++ b/patches/default.nix
@@ -55,9 +55,6 @@ final: prev: {
     proprietaryCodecs = true;
     enableWidevine = true;
   };
-  flameshot = prev.flameshot.overrideAttrs (old: {
-    qtWrapperArgs = [ "--set QT_SCALE_FACTOR_ROUNDING_POLICY Round" ] ++ old.qtWrapperArgs or [ ];
-  });
   python3 =
     let
       pythonPackagesOverlays = (prev.pythonPackagesOverlays or [ ]) ++ [


### PR DESCRIPTION
- **fix(flameshot): use legacy x11 capture when using qtile**
- **fix(gnome): add gnome-keyring's portal config to xdg-desktop-portal**
- **fix(mother): remove pentablet**
